### PR TITLE
feat: 2-byte message key + SCM_RIGHTS fd passing

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,8 +1,10 @@
 # sigexec — quick reference for Claude Code
 
-A small Unix-socket-driven command runner. Each connection sends one line; the
-server writes `ACK!`, reads the line, and spawns the configured command with
-the line appended as the last argument.
+A small Unix-socket-driven command runner. Each connection sends a 2-byte
+ASCII message key followed by either a line (key `01`) or an `SCM_RIGHTS` fd
+(key `02`); the server writes `ACK!` and then spawns the configured command
+with either the line appended as argv (`01`) or with the passed fd as stdin
+(`02`).
 
 ## Build & test
 
@@ -19,13 +21,41 @@ nix develop -c zig build -Dtarget=x86_64-linux-gnu    # cross-compile
 nix develop -c zig build test                         # test step (no unit tests yet)
 ```
 
+## Wire protocol
+
+Each connection: server writes `ACK!\n`, then the client sends a 2-byte ASCII
+message key.
+
+| Key  | Behavior                                                                                          |
+|------|---------------------------------------------------------------------------------------------------|
+| `01` | Read a `\n`-terminated line from the socket; spawn the command with the line appended as argv.    |
+| `02` | Receive a single `SCM_RIGHTS` ancillary fd; spawn the command with that fd dup2'd onto stdin.     |
+
+For `02`, the client must use `sendmsg(2)` with `SOL_SOCKET`/`SCM_RIGHTS`
+carrying exactly one fd; the 2-byte key sits in the iovec of the same message
+so the server captures both with one `recvmsg` call.
+
 ## Manual smoke test
 
 ```sh
+# Key 01 — line-as-argv (this is what test.zsh exercises):
 ./result/bin/sigexec /tmp/sigexec.sock /usr/bin/echo "it:" &
-echo first  | socat - unix-connect:/tmp/sigexec.sock   # → "ACK!" over the socket; server prints "it: first"
-echo second | socat - unix-connect:/tmp/sigexec.sock
-echo third  | socat - unix-connect:/tmp/sigexec.sock
+printf '01first\n'  | socat - unix-connect:/tmp/sigexec.sock   # → "ACK!" on the socket; server prints "it: first"
+printf '01second\n' | socat - unix-connect:/tmp/sigexec.sock
+printf '01third\n'  | socat - unix-connect:/tmp/sigexec.sock
+```
+
+For key `02` (fd-passing), socat has no built-in `SCM_RIGHTS` mode; a few
+lines of Python suffice:
+
+```sh
+./result/bin/sigexec /tmp/sigexec.sock /usr/bin/cat &
+python3 -c '
+import os, socket, array
+fd = os.open("/etc/hostname", os.O_RDONLY)
+s = socket.socket(socket.AF_UNIX); s.connect("/tmp/sigexec.sock"); s.recv(64)
+s.sendmsg([b"02"], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [fd]).tobytes())])'
+# server prints the contents of /etc/hostname
 ```
 
 ## Cross-compile matrix

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,17 +45,23 @@ printf '01second\n' | socat - unix-connect:/tmp/sigexec.sock
 printf '01third\n'  | socat - unix-connect:/tmp/sigexec.sock
 ```
 
-For key `02` (fd-passing), socat has no built-in `SCM_RIGHTS` mode; a few
-lines of Python suffice:
+For key `02` (fd-passing), socat has no built-in `SCM_RIGHTS` mode. Use the
+companion `sigexec-sendfd` binary (built alongside `sigexec`):
 
 ```sh
 ./result/bin/sigexec /tmp/sigexec.sock /usr/bin/cat &
+./result/bin/sigexec-sendfd /tmp/sigexec.sock /etc/hostname
+# server prints the contents of /etc/hostname
+```
+
+Or a few lines of Python:
+
+```sh
 python3 -c '
 import os, socket, array
 fd = os.open("/etc/hostname", os.O_RDONLY)
 s = socket.socket(socket.AF_UNIX); s.connect("/tmp/sigexec.sock"); s.recv(64)
 s.sendmsg([b"02"], [(socket.SOL_SOCKET, socket.SCM_RIGHTS, array.array("i", [fd]).tobytes())])'
-# server prints the contents of /etc/hostname
 ```
 
 ## Cross-compile matrix

--- a/build.zig
+++ b/build.zig
@@ -14,6 +14,16 @@ pub fn build(b: *std.Build) void {
     });
     b.installArtifact(exe);
 
+    const sendfd = b.addExecutable(.{
+        .name = "sigexec-sendfd",
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/sendfd.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
+    });
+    b.installArtifact(sendfd);
+
     const run_exe = b.addRunArtifact(exe);
     run_exe.step.dependOn(b.getInstallStep());
     if (b.args) |args| run_exe.addArgs(args);

--- a/flake.nix
+++ b/flake.nix
@@ -35,12 +35,7 @@
           });
       writeZsh = pkgs.writers.makeScriptWriter {interpreter = "${pkgs.zsh}/bin/zsh";};
       socat = pkgs.socat;
-    in {
-      devShells.default = pkgs.mkShell {
-        buildInputs = [zig socat];
-      };
-      devShell = self.devShells.${system}.default;
-      packages.default = build_zig {
+      sigexec = build_zig {
         pname = "sigexec";
         version = "0.0.3";
         src = ./.;
@@ -50,12 +45,29 @@
           description = "A simple utility that runs a command with each line sent over a socket.";
           license = licenses.mit;
           platforms = platforms.linux ++ platforms.darwin;
+          mainProgram = "sigexec";
         };
+      };
+    in {
+      devShells.default = pkgs.mkShell {
+        buildInputs = [zig socat];
+      };
+      devShell = self.devShells.${system}.default;
+      packages.default = sigexec;
+      packages.sigexec = sigexec;
+      packages.sigexec-sendfd = sigexec;
+      apps.sigexec = {
+        type = "app";
+        program = "${sigexec}/bin/sigexec";
+      };
+      apps.sigexec-sendfd = {
+        type = "app";
+        program = "${sigexec}/bin/sigexec-sendfd";
       };
       apps.do-test = {
         type = "app";
         program = toString (writeZsh "test.zsh" ''
-          PATH="$PATH:${self.packages.${system}.default}/bin:${socat}/bin"
+          PATH="$PATH:${sigexec}/bin:${socat}/bin"
           ${(builtins.readFile ./test.zsh)}
         '');
       };

--- a/src/main.zig
+++ b/src/main.zig
@@ -1,6 +1,7 @@
 const std = @import("std");
 const Io = std.Io;
 const net = std.Io.net;
+const posix = std.posix;
 
 pub fn main(init: std.process.Init) !void {
     const io = init.io;
@@ -35,16 +36,48 @@ fn handle(
     defer arena_state.deinit();
     const alloc = arena_state.allocator();
 
-    var read_buf: [1024]u8 = undefined;
     var write_buf: [64]u8 = undefined;
-    var sr = stream.reader(io, &read_buf);
     var sw = stream.writer(io, &write_buf);
-
     sw.interface.writeAll("ACK!\n") catch return;
     sw.interface.flush() catch return;
 
-    const line = sr.interface.takeDelimiterExclusive('\n') catch return;
+    var key: [2]u8 = undefined;
+    var passed_fd: ?posix.fd_t = null;
+    recvKey(stream.socket.handle, &key, &passed_fd) catch |err| {
+        if (passed_fd) |fd| closeFd(fd);
+        std.log.err("recv key failed: {s}", .{@errorName(err)});
+        return;
+    };
 
+    if (std.mem.eql(u8, &key, "01")) {
+        if (passed_fd) |fd| {
+            closeFd(fd);
+            std.log.err("unexpected fd with message key 01", .{});
+            return;
+        }
+        var read_buf: [1024]u8 = undefined;
+        var sr = stream.reader(io, &read_buf);
+        const line = sr.interface.takeDelimiterExclusive('\n') catch return;
+        runWithLine(io, alloc, cmd_args, line);
+    } else if (std.mem.eql(u8, &key, "02")) {
+        const fd = passed_fd orelse {
+            std.log.err("message key 02 missing file descriptor", .{});
+            return;
+        };
+        defer closeFd(fd);
+        runWithStdin(io, cmd_args, fd);
+    } else {
+        if (passed_fd) |fd| closeFd(fd);
+        std.log.err("unknown message key: {s}", .{&key});
+    }
+}
+
+fn runWithLine(
+    io: Io,
+    alloc: std.mem.Allocator,
+    cmd_args: []const []const u8,
+    line: []const u8,
+) void {
     var dynargs: std.ArrayList([]const u8) = .empty;
     defer dynargs.deinit(alloc);
     dynargs.appendSlice(alloc, cmd_args) catch return;
@@ -56,4 +89,87 @@ fn handle(
         return;
     };
     _ = child.wait(io) catch {};
+}
+
+fn runWithStdin(io: Io, cmd_args: []const []const u8, fd: posix.fd_t) void {
+    var child = std.process.spawn(io, .{
+        .argv = cmd_args,
+        .stdin = .{ .file = .{ .handle = fd, .flags = .{ .nonblocking = false } } },
+    }) catch |err| {
+        std.log.err("spawn failed: {s}", .{@errorName(err)});
+        return;
+    };
+    _ = child.wait(io) catch {};
+}
+
+fn closeFd(fd: posix.fd_t) void {
+    _ = posix.system.close(fd);
+}
+
+/// Reads exactly `key.len` bytes from `sock_fd` using `recvmsg(2)` so an
+/// `SCM_RIGHTS` ancillary message attached to the same datagram can be
+/// captured. If a single fd was passed, it is stored in `out_fd`.
+fn recvKey(sock_fd: posix.fd_t, key: *[2]u8, out_fd: *?posix.fd_t) !void {
+    var iov: posix.iovec = .{ .base = key[0..].ptr, .len = key.len };
+    var ctl_buf: [64]u8 align(@alignOf(usize)) = undefined;
+    var msg: posix.msghdr = .{
+        .name = null,
+        .namelen = 0,
+        .iov = (&iov)[0..1],
+        .iovlen = 1,
+        .control = &ctl_buf,
+        .controllen = ctl_buf.len,
+        .flags = undefined,
+    };
+
+    const cloexec: u32 = if (@hasDecl(posix.MSG, "CMSG_CLOEXEC")) posix.MSG.CMSG_CLOEXEC else 0;
+
+    var got: usize = 0;
+    while (true) {
+        const rc = posix.system.recvmsg(sock_fd, &msg, cloexec);
+        switch (posix.errno(rc)) {
+            .SUCCESS => {},
+            .INTR => continue,
+            else => return error.RecvFailed,
+        }
+        const n: usize = @intCast(rc);
+        if (n == 0) return error.EndOfStream;
+        got = n;
+        break;
+    }
+
+    if (msg.controllen != 0) {
+        if (msg.control) |ptr| {
+            const cmsg: *const posix.system.cmsghdr = @ptrCast(@alignCast(ptr));
+            if (cmsg.level == posix.SOL.SOCKET and cmsg.type == posix.SCM.RIGHTS) {
+                const data_off = std.mem.alignForward(usize, @sizeOf(posix.system.cmsghdr), @alignOf(usize));
+                const bytes: [*]const u8 = @ptrCast(ptr);
+                var fd_val: c_int = undefined;
+                @memcpy(std.mem.asBytes(&fd_val), bytes[data_off..][0..@sizeOf(c_int)]);
+                out_fd.* = @intCast(fd_val);
+            }
+        }
+    }
+
+    while (got < key.len) {
+        var iov2: posix.iovec = .{ .base = key[got..].ptr, .len = key.len - got };
+        var msg2: posix.msghdr = .{
+            .name = null,
+            .namelen = 0,
+            .iov = (&iov2)[0..1],
+            .iovlen = 1,
+            .control = null,
+            .controllen = 0,
+            .flags = undefined,
+        };
+        const rc = posix.system.recvmsg(sock_fd, &msg2, 0);
+        switch (posix.errno(rc)) {
+            .SUCCESS => {},
+            .INTR => continue,
+            else => return error.RecvFailed,
+        }
+        const n: usize = @intCast(rc);
+        if (n == 0) return error.EndOfStream;
+        got += n;
+    }
 }

--- a/src/main.zig
+++ b/src/main.zig
@@ -107,8 +107,10 @@ fn closeFd(fd: posix.fd_t) void {
 }
 
 /// Reads exactly `key.len` bytes from `sock_fd` using `recvmsg(2)` so an
-/// `SCM_RIGHTS` ancillary message attached to the same datagram can be
-/// captured. If a single fd was passed, it is stored in `out_fd`.
+/// `SCM_RIGHTS` ancillary message carried by the same `sendmsg` call can be
+/// captured. If exactly one fd was passed, it is stored in `out_fd`; any
+/// other count (zero with no key-02, or more than one) is closed and
+/// reported as an error.
 fn recvKey(sock_fd: posix.fd_t, key: *[2]u8, out_fd: *?posix.fd_t) !void {
     var iov: posix.iovec = .{ .base = key[0..].ptr, .len = key.len };
     var ctl_buf: [64]u8 align(@alignOf(usize)) = undefined;
@@ -138,18 +140,7 @@ fn recvKey(sock_fd: posix.fd_t, key: *[2]u8, out_fd: *?posix.fd_t) !void {
         break;
     }
 
-    if (msg.controllen != 0) {
-        if (msg.control) |ptr| {
-            const cmsg: *const posix.system.cmsghdr = @ptrCast(@alignCast(ptr));
-            if (cmsg.level == posix.SOL.SOCKET and cmsg.type == posix.SCM.RIGHTS) {
-                const data_off = std.mem.alignForward(usize, @sizeOf(posix.system.cmsghdr), @alignOf(usize));
-                const bytes: [*]const u8 = @ptrCast(ptr);
-                var fd_val: c_int = undefined;
-                @memcpy(std.mem.asBytes(&fd_val), bytes[data_off..][0..@sizeOf(c_int)]);
-                out_fd.* = @intCast(fd_val);
-            }
-        }
-    }
+    try parseControlForFd(&msg, out_fd);
 
     while (got < key.len) {
         var iov2: posix.iovec = .{ .base = key[got..].ptr, .len = key.len - got };
@@ -172,4 +163,71 @@ fn recvKey(sock_fd: posix.fd_t, key: *[2]u8, out_fd: *?posix.fd_t) !void {
         if (n == 0) return error.EndOfStream;
         got += n;
     }
+}
+
+/// Walks every `cmsghdr` in `msg.control`, collecting fds from any
+/// `SCM_RIGHTS` messages. Errors out (and closes every collected fd) if the
+/// kernel truncated the control buffer, the cmsg layout is malformed, or
+/// anything other than exactly one fd was sent.
+fn parseControlForFd(msg: *const posix.msghdr, out_fd: *?posix.fd_t) !void {
+    const ctl_len: usize = @intCast(msg.controllen);
+    if (ctl_len == 0) return;
+    const ctl_ptr = msg.control orelse return;
+
+    if ((msg.flags & posix.MSG.CTRUNC) != 0) return error.ControlTruncated;
+
+    const base: [*]const u8 = @ptrCast(ctl_ptr);
+    const hdr_size = @sizeOf(posix.system.cmsghdr);
+    const data_off = std.mem.alignForward(usize, hdr_size, @alignOf(usize));
+
+    var fds: [4]posix.fd_t = undefined;
+    var n_fds: usize = 0;
+    var off: usize = 0;
+    while (off + hdr_size <= ctl_len) {
+        const cmsg: *const posix.system.cmsghdr = @ptrCast(@alignCast(base + off));
+        const cmsg_len: usize = @intCast(cmsg.len);
+        if (cmsg_len < data_off or off + cmsg_len > ctl_len) {
+            closeCollected(&fds, n_fds);
+            return error.MalformedCmsg;
+        }
+
+        if (cmsg.level == posix.SOL.SOCKET and cmsg.type == posix.SCM.RIGHTS) {
+            const payload_len = cmsg_len - data_off;
+            if (payload_len % @sizeOf(c_int) != 0) {
+                closeCollected(&fds, n_fds);
+                return error.MalformedCmsg;
+            }
+            const cmsg_n_fds = payload_len / @sizeOf(c_int);
+            var i: usize = 0;
+            while (i < cmsg_n_fds) : (i += 1) {
+                var fd_val: c_int = undefined;
+                @memcpy(
+                    std.mem.asBytes(&fd_val),
+                    (base + off + data_off + i * @sizeOf(c_int))[0..@sizeOf(c_int)],
+                );
+                const fd: posix.fd_t = @intCast(fd_val);
+                if (n_fds < fds.len) {
+                    fds[n_fds] = fd;
+                } else {
+                    closeFd(fd);
+                }
+                n_fds += 1;
+            }
+        }
+        off = std.mem.alignForward(usize, off + cmsg_len, @alignOf(usize));
+    }
+
+    if (n_fds == 1) {
+        out_fd.* = fds[0];
+        return;
+    }
+    if (n_fds > 1) {
+        closeCollected(&fds, @min(n_fds, fds.len));
+        return error.TooManyFds;
+    }
+}
+
+fn closeCollected(fds: *const [4]posix.fd_t, n: usize) void {
+    var i: usize = 0;
+    while (i < n) : (i += 1) closeFd(fds[i]);
 }

--- a/src/sendfd.zig
+++ b/src/sendfd.zig
@@ -1,0 +1,75 @@
+const std = @import("std");
+const Io = std.Io;
+const net = std.Io.net;
+const posix = std.posix;
+
+pub fn main(init: std.process.Init) !void {
+    const io = init.io;
+    const arena = init.arena.allocator();
+
+    const args = try init.minimal.args.toSlice(arena);
+    if (args.len < 3) {
+        std.log.err("Usage: sigexec-sendfd <socket> <file>", .{});
+        return error.InvalidUsage;
+    }
+    const sock_path = args[1];
+    const file_path = args[2];
+
+    var file = try std.Io.Dir.cwd().openFile(io, file_path, .{});
+    defer file.close(io);
+
+    const addr = try net.UnixAddress.init(sock_path);
+    var stream = try addr.connect(io);
+    defer stream.close(io);
+
+    var read_buf: [16]u8 = undefined;
+    var sr = stream.reader(io, &read_buf);
+    _ = sr.interface.takeDelimiterExclusive('\n') catch |err| {
+        std.log.err("server did not ACK: {s}", .{@errorName(err)});
+        return err;
+    };
+
+    try sendKeyWithFd(stream.socket.handle, file.handle);
+}
+
+fn sendKeyWithFd(sock_fd: posix.fd_t, fd: posix.fd_t) !void {
+    var key: [2]u8 = "02".*;
+    var iov: posix.iovec_const = .{ .base = &key, .len = key.len };
+
+    const data_off = std.mem.alignForward(usize, @sizeOf(posix.system.cmsghdr), @alignOf(usize));
+    const cmsg_len = data_off + @sizeOf(c_int);
+    const cmsg_space = std.mem.alignForward(usize, cmsg_len, @alignOf(usize));
+
+    var ctl: [64]u8 align(@alignOf(usize)) = @splat(0);
+    const cmsg: *posix.system.cmsghdr = @ptrCast(@alignCast(&ctl));
+    cmsg.* = .{
+        .len = @intCast(cmsg_len),
+        .level = posix.SOL.SOCKET,
+        .type = posix.SCM.RIGHTS,
+    };
+    var fd_val: c_int = @intCast(fd);
+    @memcpy(ctl[data_off..][0..@sizeOf(c_int)], std.mem.asBytes(&fd_val));
+
+    var msg: posix.msghdr_const = .{
+        .name = null,
+        .namelen = 0,
+        .iov = (&iov)[0..1],
+        .iovlen = 1,
+        .control = &ctl,
+        .controllen = @intCast(cmsg_space),
+        .flags = 0,
+    };
+
+    const flags: u32 = if (@hasDecl(posix.MSG, "NOSIGNAL")) posix.MSG.NOSIGNAL else 0;
+    while (true) {
+        const rc = posix.system.sendmsg(sock_fd, &msg, flags);
+        switch (posix.errno(rc)) {
+            .SUCCESS => return,
+            .INTR => continue,
+            else => |e| {
+                std.log.err("sendmsg failed: {s}", .{@tagName(e)});
+                return error.SendFailed;
+            },
+        }
+    }
+}

--- a/test.zsh
+++ b/test.zsh
@@ -18,9 +18,9 @@ while ! [[ -S "$socket" ]]; do
   sleep 5
 done
 
-echo  first | socat - unix-connect:"$socket"
-echo second | socat - unix-connect:"$socket"
-echo  third | socat - unix-connect:"$socket"
+printf '01%s\n' first  | socat - unix-connect:"$socket"
+printf '01%s\n' second | socat - unix-connect:"$socket"
+printf '01%s\n' third  | socat - unix-connect:"$socket"
 
 ## Expected Output
 


### PR DESCRIPTION
Each connection now starts with a 2-byte ASCII message key:
  01 — current behavior (read a line, append as argv, spawn command).
  02 — receive a single SCM_RIGHTS fd via sendmsg(2) and spawn the
       command with that fd dup2'd onto stdin.

The server uses recvmsg(2) on the underlying socket fd so the key and
ancillary fd that travel together in one sendmsg are captured in one
syscall. test.zsh and the CLAUDE.md smoke test commands are updated to
prefix payloads with "01"; key 02 is documented with a Python example
since socat has no built-in SCM_RIGHTS mode.

https://claude.ai/code/session_01BRfCs6vRaR7sAVqpcsWaAy